### PR TITLE
fix: use git worktree to initialize badges branch safely

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -194,8 +194,9 @@ trap 'git worktree remove --force "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir
 
 git worktree add --orphan -b badges "$tmpdir"
 
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/coverage.svg"
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/time.svg"
+_svg='<svg xmlns="http://www.w3.org/2000/svg"/>'
+printf '%s' "$_svg" > "$tmpdir/coverage.svg"
+printf '%s' "$_svg" > "$tmpdir/time.svg"
 
 git -C "$tmpdir" add coverage.svg time.svg
 git -C "$tmpdir" commit -m "chore: initialize badges branch [skip ci]"

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -184,12 +184,21 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-git checkout --orphan badges
-git rm -rf .
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > coverage.svg
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > time.svg
-git add coverage.svg time.svg
-git commit -m "chore: initialize badges branch [skip ci]"
-git checkout -
+if git show-ref --verify --quiet refs/heads/badges; then
+  echo "Error: 'badges' branch already exists. Delete it first: git branch -D badges" >&2
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'git worktree remove --force "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
+
+git worktree add --orphan -b badges "$tmpdir"
+
+printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/coverage.svg"
+printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/time.svg"
+
+git -C "$tmpdir" add coverage.svg time.svg
+git -C "$tmpdir" commit -m "chore: initialize badges branch [skip ci]"
+
 echo "Badges branch initialized. Run: git push origin badges"
 """


### PR DESCRIPTION
## Summary

- `badges:init` タスクの `git checkout --orphan` + `git rm -rf .` を廃止
- `git worktree add --orphan` で一時ディレクトリに隔離し、メインの作業ツリーを一切触らない実装に変更
- `trap EXIT` でスクリプト失敗時も worktree が自動クリーンアップされる
- `badges` ブランチが既に存在する場合の事前チェックを追加
- SVG 文字列を `_svg` 変数に抽出し `printf '%s'` を使うよう整理

## Test plan

- [ ] `badges` ブランチが存在しない状態で `mise run badges:init` を実行し、`badges` ブランチに `coverage.svg` と `time.svg` のみがコミットされることを確認
- [ ] `badges` ブランチが既に存在する状態で実行するとエラーメッセージを出して終了することを確認
- [ ] スクリプト途中で `Ctrl+C` しても作業ツリーに影響がないことを確認