### PR TITLE
fix: push coverage badges via GitHub Git Data API

### DIFF
--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/python-ci.yaml
     permissions:
       actions: read # octocov artifact
-      contents: write # octocov badge push
+      contents: write # push coverage badges to badges branch
       pull-requests: write # octocov comment
 
   audit:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(needs.setup.outputs.timeout_minutes) }}
     permissions:
       actions: read # For octocov to retrieve previous reports from artifacts
-      contents: write # For octocov to push badges to repository
+      contents: write # For pushing coverage badges to the badges branch
       pull-requests: write # For octocov to comment on pull requests
 
     steps:
@@ -73,3 +73,54 @@ jobs:
         uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push coverage badges
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          [[ -f coverage.svg && -f time.svg ]] || { echo "Badge files not found, skipping"; exit 0; }
+
+          # Create blobs via stdin (avoids shell argument size limits)
+          coverage_blob=$(base64 -w0 coverage.svg \
+            | jq -Rsc '{"encoding":"base64","content":.}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/blobs" --method POST --input - --jq '.sha')
+          time_blob=$(base64 -w0 time.svg \
+            | jq -Rsc '{"encoding":"base64","content":.}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/blobs" --method POST --input - --jq '.sha')
+
+          # Get current badges branch state
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" --jq '.object.sha')
+          tree_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}" --jq '.tree.sha')
+
+          # Skip if content unchanged (compare blob SHAs)
+          coverage_existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${tree_sha}" \
+            --jq '.tree[] | select(.path == "coverage.svg") | .sha')
+          time_existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${tree_sha}" \
+            --jq '.tree[] | select(.path == "time.svg") | .sha')
+          if [[ "$coverage_blob" == "$coverage_existing" && "$time_blob" == "$time_existing" ]]; then
+            echo "No badge changes"
+            exit 0
+          fi
+
+          # Build new tree and commit via API (API commits are signed by GitHub)
+          tree_json=$(printf \
+            '[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]' \
+            "$coverage_blob" "$time_blob")
+          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
+            --method POST --field base_tree="${tree_sha}" \
+            --field tree="${tree_json}" --jq '.sha')
+
+          parents_json=$(printf '["%s"]' "$head_sha")
+          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
+            --method POST \
+            --field message="Update coverage badges [skip ci]" \
+            --field tree="${new_tree}" \
+            --field parents="${parents_json}" --jq '.sha')
+
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" \
+            --method PATCH --field sha="${new_commit}"
+          echo "Coverage badges updated"

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -194,8 +194,9 @@ trap 'git worktree remove --force "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir
 
 git worktree add --orphan -b badges "$tmpdir"
 
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/coverage.svg"
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/time.svg"
+_svg='<svg xmlns="http://www.w3.org/2000/svg"/>'
+printf '%s' "$_svg" > "$tmpdir/coverage.svg"
+printf '%s' "$_svg" > "$tmpdir/time.svg"
 
 git -C "$tmpdir" add coverage.svg time.svg
 git -C "$tmpdir" commit -m "chore: initialize badges branch [skip ci]"

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -184,12 +184,21 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-git checkout --orphan badges
-git rm -rf .
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > coverage.svg
-printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > time.svg
-git add coverage.svg time.svg
-git commit -m "chore: initialize badges branch [skip ci]"
-git checkout -
+if git show-ref --verify --quiet refs/heads/badges; then
+  echo "Error: 'badges' branch already exists. Delete it first: git branch -D badges" >&2
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'git worktree remove --force "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
+
+git worktree add --orphan -b badges "$tmpdir"
+
+printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/coverage.svg"
+printf '<svg xmlns="http://www.w3.org/2000/svg"/>' > "$tmpdir/time.svg"
+
+git -C "$tmpdir" add coverage.svg time.svg
+git -C "$tmpdir" commit -m "chore: initialize badges branch [skip ci]"
+
 echo "Badges branch initialized. Run: git push origin badges"
 """

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,11 +21,6 @@ coverage:
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
-push:
-  if: is_default_branch
-  datastores:
-    - github://${GITHUB_REPOSITORY}@badges
-  message: "Update coverage badges [skip ci]"
 report:
   if: is_default_branch
   datastores:


### PR DESCRIPTION
## Summary

- octocov の組み込み push が `.gitignore` により `coverage.svg` / `time.svg` を認識できず、バッジが更新されない問題を修正
- `.octocov.yml` の `push` セクションを削除し、CI の専用ステップに置き換え
- GitHub Git Data API (blob → tree → commit → ref) で 1 つのアトミックコミットとして badges ブランチを更新
- blob は stdin パイプで作成 (シェル引数サイズ制限を回避)
- blob SHA が変化していない場合はスキップ
- API 経由のコミットは GitHub が自動署名

## Root cause

octocov の `PushUsingLocalGit` は go-git の `Worktree.Status()` でファイルを検出するが、`.gitignore` に列挙されたファイルは git status に出てこないためステージ不可。

## Test plan

- [ ] main へのマージ後に CI が実行され、badges ブランチに `coverage.svg` / `time.svg` が更新されることを確認
- [ ] 2 回目の実行 (badge 内容が同じ) で "No badge changes" と表示されスキップされることを確認