### PR TITLE
fix: use --input - for git tree and commit API calls

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -107,19 +107,16 @@ jobs:
           fi
 
           # Build new tree and commit via API (API commits are signed by GitHub)
-          tree_json=$(printf \
-            '[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]' \
-            "$coverage_blob" "$time_blob")
-          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
-            --method POST --field base_tree="${tree_sha}" \
-            --field tree="${tree_json}" --jq '.sha')
+          # Use --input - to pass complete JSON body, avoiding --field parsing issues
+          new_tree=$(printf \
+            '{"base_tree":"%s","tree":[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]}' \
+            "$tree_sha" "$coverage_blob" "$time_blob" \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/trees" --method POST --input - --jq '.sha')
 
-          parents_json=$(printf '["%s"]' "$head_sha")
-          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
-            --method POST \
-            --field message="Update coverage badges [skip ci]" \
-            --field tree="${new_tree}" \
-            --field parents="${parents_json}" --jq '.sha')
+          new_commit=$(printf \
+            '{"message":"Update coverage badges [skip ci]","tree":"%s","parents":["%s"]}' \
+            "$new_tree" "$head_sha" \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/commits" --method POST --input - --jq '.sha')
 
           gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" \
             --method PATCH --field sha="${new_commit}"


### PR DESCRIPTION
## Summary

- PR #765 で `--field tree=` に JSON 配列を渡すと `gh api` が文字列としてラップし HTTP 422 になる問題を修正
- tree 作成・commit 作成の両 API 呼び出しを `--input -` (stdin 経由の完全 JSON ボディ) に変更

## Root cause

`gh api --field key=[...]` は値が `[` で始まっても JSON 配列として渡されず、GitHub Git Trees API が `Invalid tree info (HTTP 422)` を返していた。

## Test plan

- [ ] main へのマージ後、badges ブランチに `coverage.svg` / `time.svg` が実際に更新されることを確認