### PR TITLE
feat(devcontainer): add devcontainer CLI + traefik routing support

### DIFF
--- a/.claude/skills/project-conventions/SKILL.md
+++ b/.claude/skills/project-conventions/SKILL.md
@@ -14,24 +14,34 @@ license: AGPL-3.0
 
 All tasks go through `mise run`:
 
-| Task                  | Command               |
-| --------------------- | --------------------- |
-| Setup                 | `mise run setup`      |
-| Install               | `mise run install`    |
-| Build                 | `mise run build`      |
-| Test                  | `mise run test`       |
-| Coverage view (HTML)  | `mise run test:view`  |
-| Format                | `mise run fmt`        |
-| Format check          | `mise run fmt:check`  |
-| Ruff lint             | `mise run ruff:check` |
-| Type check (mypy)     | `mise run mypy`       |
-| Lint                  | `mise run lint`       |
-| Lint (GitHub Actions) | `mise run lint:gh`    |
-| Pre-commit (required) | `mise run pre-commit` |
-| Pre-push              | `mise run pre-push`   |
-| Docs                  | `mise run docs`       |
-| Docs (live)           | `mise run docs:live`  |
-| Clean                 | `mise run clean`      |
+| Task                  | Command                       |
+| --------------------- | ----------------------------- |
+| Setup                 | `mise run setup`              |
+| Install               | `mise run install`            |
+| Build                 | `mise run build`              |
+| Test                  | `mise run test`               |
+| Coverage view (HTML)  | `mise run test:view`          |
+| Format                | `mise run fmt`                |
+| Format check          | `mise run fmt:check`          |
+| Ruff lint             | `mise run ruff:check`         |
+| Type check (mypy)     | `mise run mypy`               |
+| Lint                  | `mise run lint`               |
+| Lint (GitHub Actions) | `mise run lint:gh`            |
+| Pre-commit (required) | `mise run pre-commit`         |
+| Pre-push              | `mise run pre-push`           |
+| Docs                  | `mise run docs`               |
+| Docs (live)           | `mise run docs:live`          |
+| Clean                 | `mise run clean`              |
+| Audit (deps)          | `mise run audit`              |
+| Badges (init)         | `mise run badges:init`        |
+| Claude Code (install) | `mise run claudecode:install` |
+| CodeQL (install)      | `mise run codeql:install`     |
+| CodeQL (analyze)      | `mise run codeql`             |
+| Dev (start)           | `mise run dev:up`             |
+| Dev (stop)            | `mise run dev:down`           |
+| Dev (exec)            | `mise run dev:exec`           |
+| Dev (status)          | `mise run dev:status`         |
+| Traefik setup         | `mise run traefik:setup`      |
 
 ## Python Coding Rules
 

--- a/.devcontainer/traefik.sh
+++ b/.devcontainer/traefik.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+# .devcontainer/traefik.sh <command>
+# Commands: setup | up | down | exec | status
+#
+# Must be run on the WSL2 host, not inside a devcontainer.
+set -euo pipefail
+
+readonly TRAEFIK_BIN="${HOME}/.local/bin/traefik"
+readonly TRAEFIK_CONFIG="${HOME}/.config/traefik/traefik.yml"
+readonly TRAEFIK_DYNAMIC_DIR="${HOME}/.config/traefik/dynamic"
+readonly TRAEFIK_DYNAMIC_CONTAINER_PATH=/traefik-dynamic
+readonly TRAEFIK_SERVICE="${HOME}/.config/systemd/user/traefik.service"
+readonly TRAEFIK_PORT_ROUTER=8080
+readonly TRAEFIK_PORT_DASHBOARD=8081
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_host_check() {
+	if [ "${MISE_ENV:-}" = "devcontainer" ] || [ -f "/.dockerenv" ]; then
+		echo "Error: must be run on the WSL2 host, not inside a devcontainer." >&2
+		exit 1
+	fi
+}
+
+_workspace() {
+	git rev-parse --show-toplevel
+}
+
+_project() {
+	basename "$(_workspace)"
+}
+
+_branch() {
+	local workspace raw
+	workspace="$(_workspace)"
+	raw="$(git -C "${workspace}" branch --show-current 2>/dev/null || true)"
+	if [ -z "${raw}" ]; then
+		raw="detached-$(git -C "${workspace}" rev-parse --short HEAD)"
+	fi
+	printf '%s' "${raw}" \
+		| tr '[:upper:]' '[:lower:]' \
+		| sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' \
+		| cut -c1-63
+}
+
+# Strip single-line comments (//) from JSONC before passing to jq
+_jsonc() {
+	sed -e '/^[[:space:]]*\/\//d' -e 's|[[:space:]]//[^"]*$||g' "${1}"
+}
+
+_ports() {
+	local devcontainer_json
+	devcontainer_json="$(_workspace)/.devcontainer/devcontainer.json"
+	_jsonc "${devcontainer_json}" | jq -r '.portsAttributes | keys[]' 2>/dev/null || true
+}
+
+# Find container ID for the current workspace (running or stopped).
+# Uses devcontainer.local_folder label (set by devcontainer CLI) so the lookup
+# is stable across branch changes inside the container.
+_container_id() {
+	local workspace
+	workspace="$(_workspace)"
+	docker ps -aq --filter "label=devcontainer.local_folder=${workspace}"
+}
+
+# Find running container ID only.
+_running_container_id() {
+	local workspace
+	workspace="$(_workspace)"
+	docker ps -q --filter "label=devcontainer.local_folder=${workspace}"
+}
+
+_ensure_network() {
+	docker network inspect devcontainer-traefik >/dev/null 2>&1 \
+		|| docker network create devcontainer-traefik
+}
+
+# Write traefik file-provider YAML for all ports of one container.
+# Usage: _write_routes <container_id> <project> <branch> <ip> <ports_newline_separated>
+_write_routes() {
+	local cid="${1}" project="${2}" branch="${3}" ip="${4}" ports="${5}"
+	local cid_short="${cid:0:12}"
+	local dest="${TRAEFIK_DYNAMIC_DIR}/${project}-${cid_short}.yml"
+	local bt='`'
+
+	{
+		printf 'http:\n'
+		printf '  routers:\n'
+		while IFS= read -r port; do
+			[ -z "${port}" ] && continue
+			local router="p${port}-${branch}--${project}"
+			local fqdn="p${port}.${branch}.${project}.localhost"
+			printf '    %s:\n' "${router}"
+			printf '      rule: "Host(%s%s%s)"\n' "${bt}" "${fqdn}" "${bt}"
+			printf '      entryPoints:\n'
+			printf '        - web\n'
+			printf '      service: %s\n' "${router}"
+		done <<< "${ports}"
+		printf '  services:\n'
+		while IFS= read -r port; do
+			[ -z "${port}" ] && continue
+			local router="p${port}-${branch}--${project}"
+			printf '    %s:\n' "${router}"
+			printf '      loadBalancer:\n'
+			printf '        servers:\n'
+			printf '          - url: "http://%s:%s"\n' "${ip}" "${port}"
+		done <<< "${ports}"
+	} > "${dest}"
+	echo "Wrote ${dest}"
+}
+
+# Remove the file-provider YAML for a container.
+_remove_routes() {
+	local cid="${1}" project="${2}"
+	local cid_short="${cid:0:12}"
+	local dest="${TRAEFIK_DYNAMIC_DIR}/${project}-${cid_short}.yml"
+	rm -f "${dest}" && echo "Removed ${dest}"
+}
+
+# Query GitHub releases API for the latest traefik tag (e.g. "v3.4.1")
+_traefik_latest() {
+	curl -sfSL --retry 3 \
+		https://api.github.com/repos/traefik/traefik/releases/latest \
+		| jq -r '.tag_name'
+}
+
+# Print the installed traefik version tag (e.g. "v3.4.0"), or empty string
+_traefik_installed() {
+	if [ ! -x "${TRAEFIK_BIN}" ]; then
+		echo ""
+		return
+	fi
+	# "traefik version" output: "Version:      3.4.1" (variable spacing, no "v" prefix)
+	"${TRAEFIK_BIN}" version 2>/dev/null \
+		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+		| head -1 \
+		| sed 's/^/v/' \
+		|| echo ""
+}
+
+_traefik_install_version() {
+	local version arch filename url tmpfile checksums_url checksums_file expected actual
+
+	version="${1}"
+
+	case "$(uname -m)" in
+		x86_64)  arch="amd64" ;;
+		aarch64) arch="arm64" ;;
+		*)
+			echo "Error: unsupported architecture $(uname -m)" >&2
+			exit 1
+			;;
+	esac
+
+	filename="traefik_${version}_linux_${arch}.tar.gz"
+	url="https://github.com/traefik/traefik/releases/download/${version}/${filename}"
+	checksums_url="https://github.com/traefik/traefik/releases/download/${version}/traefik_${version}_checksums.txt"
+
+	tmpfile="$(mktemp)"
+	checksums_file="$(mktemp)"
+
+	echo "Downloading traefik ${version} (${arch})..." >&2
+	if ! curl -fSL --retry 3 --retry-delay 2 --retry-connrefused -o "${tmpfile}" "${url}"; then
+		rm -f "${tmpfile}" "${checksums_file}"
+		exit 1
+	fi
+
+	echo "Verifying checksum..." >&2
+	if ! curl -fSL --retry 3 --retry-delay 2 --retry-connrefused -o "${checksums_file}" "${checksums_url}"; then
+		rm -f "${tmpfile}" "${checksums_file}"
+		echo "Error: failed to download checksums file" >&2
+		exit 1
+	fi
+
+	expected="$(awk -v f="${filename}" '$2==f{print $1}' "${checksums_file}")"
+	actual="$(sha256sum "${tmpfile}" | awk '{print $1}')"
+	rm -f "${checksums_file}"
+
+	if [ -z "${expected}" ]; then
+		rm -f "${tmpfile}"
+		echo "Error: ${filename} not found in checksums file" >&2
+		exit 1
+	fi
+	if [ "${expected}" != "${actual}" ]; then
+		rm -f "${tmpfile}"
+		echo "Error: checksum mismatch (expected ${expected}, got ${actual})" >&2
+		exit 1
+	fi
+
+	mkdir -p "${HOME}/.local/bin"
+	if ! tar -xzf "${tmpfile}" -C "${HOME}/.local/bin" traefik; then
+		rm -f "${tmpfile}"
+		echo "Error: failed to extract traefik binary" >&2
+		exit 1
+	fi
+	rm -f "${tmpfile}"
+	chmod +x "${TRAEFIK_BIN}"
+	echo "Installed traefik ${version} to ${TRAEFIK_BIN}" >&2
+}
+
+# Check installed version vs latest; install or update as needed.
+# Prints one of: "installed", "updated", "already-latest"
+_traefik_ensure_latest() {
+	local installed latest
+	installed="$(_traefik_installed)"
+	latest="$(_traefik_latest)"
+
+	if [ -z "${latest}" ]; then
+		echo "Warning: could not fetch latest traefik version from GitHub." >&2
+		if [ -z "${installed}" ]; then
+			echo "Error: traefik is not installed and version check failed." >&2
+			exit 1
+		fi
+		echo "already-latest"
+		return
+	fi
+
+	if [ -z "${installed}" ]; then
+		_traefik_install_version "${latest}"
+		echo "installed"
+	elif [ "${installed}" != "${latest}" ]; then
+		echo "Updating traefik ${installed} -> ${latest}" >&2
+		_traefik_install_version "${latest}"
+		echo "updated"
+	else
+		echo "traefik ${installed}: already at latest" >&2
+		echo "already-latest"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_setup() {
+	_host_check
+
+	_traefik_ensure_latest >/dev/null
+	# Show final installed version
+	echo "traefik: $(_traefik_installed)"
+
+	_ensure_network
+	mkdir -p "$(dirname "${TRAEFIK_CONFIG}")" "$(dirname "${TRAEFIK_SERVICE}")" "${TRAEFIK_DYNAMIC_DIR}"
+
+	# "traefik" entrypoint name overrides Traefik v3's built-in default (:8080).
+	# Without this, api.insecure creates an implicit "traefik" entrypoint at :8080
+	# which conflicts with the "web" entrypoint on the same port.
+	cat > "${TRAEFIK_CONFIG}" << YAML
+entryPoints:
+  web:
+    address: ":${TRAEFIK_PORT_ROUTER}"
+  traefik:
+    address: ":${TRAEFIK_PORT_DASHBOARD}"
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: devcontainer-traefik
+  file:
+    directory: "${TRAEFIK_DYNAMIC_DIR}"
+    watch: true
+api:
+  dashboard: true
+  insecure: true
+YAML
+	echo "Wrote ${TRAEFIK_CONFIG}"
+
+	cat > "${TRAEFIK_SERVICE}" << UNIT
+[Unit]
+Description=Traefik reverse proxy for devcontainers
+After=network.target
+
+[Service]
+ExecStart=${TRAEFIK_BIN} --configfile=${TRAEFIK_CONFIG}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+	echo "Wrote ${TRAEFIK_SERVICE}"
+
+	systemctl --user daemon-reload
+	systemctl --user enable traefik.service
+
+	if systemctl --user is-active --quiet traefik.service; then
+		echo "Restarting traefik to apply config..."
+		systemctl --user restart traefik.service
+	else
+		systemctl --user start traefik.service
+	fi
+
+	systemctl --user status traefik.service --no-pager
+	echo ""
+	echo "Traefik router:    http://localhost:${TRAEFIK_PORT_ROUTER}"
+	echo "Traefik dashboard: http://localhost:${TRAEFIK_PORT_DASHBOARD}/dashboard/"
+}
+
+cmd_up() {
+	local workspace project branch ports run_args tmpfile result container_id
+
+	_host_check
+
+	# Check traefik binary exists; install/update if needed
+	local update_result
+	update_result="$(_traefik_ensure_latest)"
+	case "${update_result}" in
+		installed) echo "traefik installed: $(_traefik_installed)" ;;
+		updated)   echo "traefik updated: $(_traefik_installed)" ;;
+	esac
+
+	cmd_down
+	_ensure_network
+
+	workspace="$(_workspace)"
+	project="$(_project)"
+	branch="$(_branch)"
+	ports="$(_ports)"
+
+	if [ -z "${ports}" ]; then
+		echo "Warning: no portsAttributes found in devcontainer.json." >&2
+	fi
+
+	run_args='["--label=devcontainer.project='"${project}"'"'
+	run_args="${run_args},\"--env=TRAEFIK_MANAGED=1\""
+	run_args="${run_args},\"--env=TRAEFIK_PROJECT=${project}\""
+	run_args="${run_args},\"--env=TRAEFIK_DYNAMIC_DIR=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
+	run_args="${run_args},\"--env=TRAEFIK_API_BASE=http://host.docker.internal:${TRAEFIK_PORT_DASHBOARD}\""
+	run_args="${run_args},\"--mount=type=bind,source=${TRAEFIK_DYNAMIC_DIR},target=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
+	run_args="${run_args},\"--add-host=host.docker.internal:host-gateway\"]"
+
+	# --override-config replaces (not merges) devcontainer.json, so we must
+	# merge our runArgs into the full base config before passing it.
+	tmpfile="$(mktemp --suffix=.json)"
+	# shellcheck disable=SC2064
+	trap "rm -f '${tmpfile}'" EXIT
+	_jsonc "${workspace}/.devcontainer/devcontainer.json" \
+		| jq --argjson args "${run_args}" '. + {runArgs: $args}' \
+		> "${tmpfile}"
+
+	result="$(devcontainer up --workspace-folder "${workspace}" --override-config "${tmpfile}")"
+	container_id="$(printf '%s' "${result}" | jq -r '.containerId')"
+
+	if [ -z "${container_id}" ] || [ "${container_id}" = "null" ]; then
+		echo "ERROR: failed to get containerId from devcontainer up" >&2
+		printf '%s\n' "${result}" >&2
+		exit 1
+	fi
+
+	local container_ip=""
+	container_ip="$(docker inspect "${container_id}" \
+		--format '{{(index .NetworkSettings.Networks "devcontainer-traefik").IPAddress}}' \
+		2>/dev/null || true)"
+	if [ -z "${container_ip}" ]; then
+		docker network connect devcontainer-traefik "${container_id}"
+		container_ip="$(docker inspect "${container_id}" \
+			--format '{{(index .NetworkSettings.Networks "devcontainer-traefik").IPAddress}}' \
+			2>/dev/null || true)"
+	fi
+
+	if [ -n "${ports}" ] && [ -n "${container_ip}" ]; then
+		_write_routes "${container_id}" "${project}" "${branch}" "${container_ip}" "${ports}"
+	fi
+
+	# Splash
+	echo ""
+	echo "=================================================="
+	echo "  ${project} / ${branch}"
+	echo "=================================================="
+	echo ""
+	echo "  Container: ${container_id:0:12}"
+	echo ""
+	if [ -n "${ports}" ]; then
+		echo "  URLs:"
+		while IFS= read -r port; do
+			[ -z "${port}" ] && continue
+			echo "    http://p${port}.${branch}.${project}.localhost:${TRAEFIK_PORT_ROUTER}"
+		done <<< "${ports}"
+		echo ""
+	fi
+	echo "  Traefik router:    http://localhost:${TRAEFIK_PORT_ROUTER}"
+	echo "  Traefik dashboard: http://localhost:${TRAEFIK_PORT_DASHBOARD}/dashboard/"
+	echo ""
+	echo "  Reconnect: mise run dev:exec"
+	echo "=================================================="
+	echo ""
+
+	_exec_and_watch
+}
+
+cmd_down() {
+	local project container_id
+
+	_host_check
+
+	project="$(_project)"
+	container_id="$(_container_id)"
+
+	if [ -z "${container_id}" ]; then
+		echo "No devcontainer found for ${project}"
+		return 0
+	fi
+
+	while IFS= read -r cid; do
+		[ -z "${cid}" ] && continue
+		_remove_routes "${cid}" "${project}"
+		docker rm -f "${cid}" > /dev/null
+		echo "Stopped: ${project} (${cid})"
+	done <<< "${container_id}"
+}
+
+_exec_and_watch() {
+	local workspace
+
+	workspace="$(_workspace)"
+
+	devcontainer exec --workspace-folder "${workspace}" bash || true
+
+	# Capture the specific container ID at bash-exit time so the background job
+	# targets only this container, not a new one started by a concurrent dev:up.
+	local exited_cid exited_project
+	exited_cid="$(_running_container_id)"
+	exited_project="$(_project)"
+
+	echo "Shell exited. Container stopping in 10s... (mise run dev:exec to reconnect)"
+	if [ -n "${exited_cid}" ]; then
+		( sleep 10
+		  _remove_routes "${exited_cid}" "${exited_project}"
+		  docker rm -f "${exited_cid}" > /dev/null 2>&1 || true ) &
+	fi
+}
+
+cmd_exec() {
+	local container_id
+
+	_host_check
+
+	container_id="$(_running_container_id)"
+
+	if [ -z "${container_id}" ]; then
+		echo "Container not running. Starting..."
+		cmd_up
+		return
+	fi
+
+	_exec_and_watch
+}
+
+cmd_status() {
+	_host_check
+	docker ps \
+		--filter "label=devcontainer.project" \
+		--format 'table {{.ID}}\t{{.Status}}\t{{.Label "devcontainer.project"}}'
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+	setup)  cmd_setup  ;;
+	up)     cmd_up     ;;
+	down)   cmd_down   ;;
+	exec)   cmd_exec   ;;
+	status) cmd_status ;;
+	*)
+		echo "Usage: $0 {setup|up|down|exec|status}" >&2
+		exit 1
+		;;
+esac

--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -264,6 +264,8 @@ files:
     strategy: replace
   - path: .devcontainer/postStartCommand.sh
     strategy: replace
+  - path: .devcontainer/traefik.sh
+    strategy: replace
 
   # .githooks
   - path: .githooks/commit-msg
@@ -376,6 +378,8 @@ files:
     strategy: create_only
   - path: .mise/tasks.toml
     strategy: replace
+  - path: .mise/tools.optional.toml
+    strategy: create_only
 
   # .vscode
   - path: .vscode/settings.json

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -129,7 +129,7 @@ curl -fsSL https://claude.ai/install.sh | sh
 """
 
 ["codeql:install"]
-description = "Create CodeQL database and download query packs"
+description = "Create CodeQL database and download query packs (requires: mise install --config-file .mise/tools.optional.toml)"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -177,6 +177,40 @@ echo "==> Results written to ${sarif_out}"
 description = "Check dependencies for known vulnerabilities"
 # CVE-2026-3219: pip itself; no fix version available yet (pip is a tooling dep, not a runtime dep)
 run = "uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219"
+
+["traefik:setup"]
+description = "Setup traefik as systemd user service for devcontainer routing (WSL2 host, run once)"
+run = ".devcontainer/traefik.sh setup"
+
+["dev:up"]
+description = "Start devcontainer with traefik routing labels for current worktree"
+run = """
+[ -n "${TMUX:-}" ] && tmux set-option -p @role claude 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @project-path "$(git rev-parse --show-toplevel)" 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "$(basename "$(git rev-parse --show-toplevel)"):$(git branch --show-current)" 2>/dev/null || true
+.devcontainer/traefik.sh up
+[ -n "${TMUX:-}" ] && tmux set-option -p @role "" 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "" 2>/dev/null || true
+"""
+
+["dev:down"]
+description = "Stop and remove devcontainer for current worktree"
+run = ".devcontainer/traefik.sh down"
+
+["dev:exec"]
+description = "Exec into running devcontainer for current worktree"
+run = """
+[ -n "${TMUX:-}" ] && tmux set-option -p @role claude 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @project-path "$(git rev-parse --show-toplevel)" 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "$(basename "$(git rev-parse --show-toplevel)"):$(git branch --show-current)" 2>/dev/null || true
+.devcontainer/traefik.sh exec
+[ -n "${TMUX:-}" ] && tmux set-option -p @role "" 2>/dev/null || true
+[ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "" 2>/dev/null || true
+"""
+
+["dev:status"]
+description = "List running devcontainers with their traefik FQDNs"
+run = ".devcontainer/traefik.sh status"
 
 ["badges:init"]
 description = "Initialize badges branch with placeholder SVGs for octocov"

--- a/.mise/tools.optional.toml
+++ b/.mise/tools.optional.toml
@@ -1,0 +1,6 @@
+# Optional tools — not installed by default.
+# Install explicitly when needed:
+#   mise install --config-file .mise/tools.optional.toml
+
+[tools]
+codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ All tasks use `mise run <task>`:
 | Claude Code (install) | `mise run claudecode:install` |
 | CodeQL (install)      | `mise run codeql:install`     |
 | CodeQL (analyze)      | `mise run codeql`             |
+| Dev (start)           | `mise run dev:up`             |
+| Dev (stop)            | `mise run dev:down`           |
+| Dev (exec)            | `mise run dev:exec`           |
+| Dev (status)          | `mise run dev:status`         |
+| Traefik setup         | `mise run traefik:setup`      |
 
 ## Commit Convention
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,88 @@ mise run test
 | `mise run build`      | Nuitka でバイナリビルド |
 | `mise run docs`       | ドキュメントビルド      |
 
+## devcontainer CLI + traefik による開発環境 (WSL2)
+
+VS Code を使わず tmux + yazi + claude code などで複数 worktree / 複数プロジェクトを
+並行開発する場合は、devcontainer CLI と traefik を組み合わせる方法を使います。
+ポート衝突なしに各 devcontainer へ `p<port>.<branch>.<project>.localhost:8080` で
+アクセスできます。
+
+### ホスト前提条件
+
+WSL2 ホストに以下が必要です。いずれもユーザーグローバルの mise で管理します
+(プロジェクトの `mise.toml` には含まれていません)。
+
+```bash
+# Node.js (devcontainer-cli の実行に必要)
+mise use --global node@lts
+
+# devcontainer CLI
+mise use --global devcontainer-cli@0.86.0
+```
+
+### 初回セットアップ (WSL2 ホストで1回だけ実行)
+
+前提条件のインストール後、以下を実行します。
+traefik バイナリの取得・設定・systemd user service への登録を一括で行います。
+
+```bash
+mise run traefik:setup
+```
+
+traefik の状態確認:
+
+```bash
+systemctl --user status traefik
+```
+
+### devcontainer の起動と停止
+
+```bash
+mise run dev:up      # 現在の worktree の devcontainer を起動
+mise run dev:down    # 現在の worktree の devcontainer を停止・削除
+mise run dev:exec    # 稼働中の devcontainer に bash で接続
+mise run dev:status  # 稼働中の devcontainer 一覧を表示
+```
+
+`dev:up` は `devcontainer.json` の `portsAttributes` に定義された全ポートに対して
+traefik ルーティングを自動設定します。起動後に以下の形式の URL が表示されます。
+
+```
+http://p<port>.<branch>.<project>.localhost:8080
+```
+
+例 (ポート `8000`、ブランチ `feature/add-auth`、プロジェクト `boilerplate-python`):
+
+```
+http://p8000.feature-add-auth.boilerplate-python.localhost:8080
+```
+
+### 複数 worktree での利用
+
+```bash
+# 1つ目の worktree
+cd /path/to/boilerplate-python
+mise run dev:up
+# -> http://p8000.main.boilerplate-python.localhost:8080
+
+# 2つ目の worktree (別ブランチ)
+cd /path/to/boilerplate-python-feat
+mise run dev:up
+# -> http://p8000.feature-x.boilerplate-python.localhost:8080
+```
+
+ブランチ名は DNS ラベル形式 (小文字英数字とハイフン、63文字以内) に自動変換されます。
+
+## オプションツール
+
+`codeql` など普段使わないツールは `.mise/tools.optional.toml` で管理しています。
+必要な時だけ明示的にインストールします:
+
+```bash
+mise install --config-file .mise/tools.optional.toml
+```
+
 ## チュートリアル
 
 [VSCode で極力手を抜いて開発するハンドブック](https://zenn.dev/naa0yama/books/python-boilerplate) を書きました

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,6 @@
 "aqua:cli/cli" = "2.90.0"
 "github:naa0yama/gh-sync" = "0.3.6"
 actionlint = "1.7.12"
-codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }
 dprint = "0.54.0"
 ghalint = "1.5.3"
 usage = "3.2.1"


### PR DESCRIPTION
## Summary

- `boilerplate-rust` PR #414 の backport
- `.devcontainer/traefik.sh` を追加 — devcontainer CLI + Traefik によるコンテナライフサイクル管理 (setup/up/down/exec/status)
- `codeql` をデフォルトインストールからオプション (`.mise/tools.optional.toml`) に移動
- `mise.toml` から `codeql` エントリを削除 (tools.optional.toml に移動)
- `.mise/tasks.toml` に 5 タスク追加: `traefik:setup`, `dev:up`, `dev:down`, `dev:exec`, `dev:status`
- `CLAUDE.md`, `README.md` に新タスクとワークフローを追記

## Test plan

- [ ] `mise run pre-commit` が通ること (fmt:check, ruff:check, mypy, lint:gh)
- [ ] `.devcontainer/traefik.sh` が実行権限を持つこと (`ls -la .devcontainer/traefik.sh`)
- [ ] `mise tasks` で新タスク 5 件が表示されること
- [ ] README に devcontainer CLI + traefik セクションが正しく表示されること